### PR TITLE
Default table view limit

### DIFF
--- a/pgadmin/frm/frmEditGrid.cpp
+++ b/pgadmin/frm/frmEditGrid.cpp
@@ -153,7 +153,7 @@ frmEditGrid::frmEditGrid(frmMain *form, const wxString &_title, pgConn *_conn, p
 	cbLimit->Append(_("1000 rows"));
 	cbLimit->Append(_("500 rows"));
 	cbLimit->Append(_("100 rows"));
-	cbLimit->SetValue(_("No limit"));
+	cbLimit->SetValue(_("1000 rows"));
 
 	// Finally, the scratchpad
 	scratchPad = new wxTextCtrl(this, -1, wxT(""), wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE | wxHSCROLL);


### PR DESCRIPTION
Tables with over a million rows take forever to load even on fast connections, 1000 would be an easier to use default.
